### PR TITLE
减少编写自定义函数时的冗余

### DIFF
--- a/oplog-core/src/main/java/com/elltor/oplog/service/IParseFunction.java
+++ b/oplog-core/src/main/java/com/elltor/oplog/service/IParseFunction.java
@@ -24,4 +24,13 @@ public interface IParseFunction {
      */
     Method functionMethod();
 
+    /**
+     * 将自定义函数注册到IParseFunction
+     * @param method
+     * @return
+     */
+    static IParseFunction fromLambda(Method method) {
+        return () -> method;
+    }
+
 }

--- a/oplog-example/src/main/java/com/elltor/example/config/CustomFunctionConfiguration.java
+++ b/oplog-example/src/main/java/com/elltor/example/config/CustomFunctionConfiguration.java
@@ -10,36 +10,28 @@ import java.lang.reflect.Method;
 @Configuration
 public class CustomFunctionConfiguration {
 
-    @Bean
-    public IParseFunction judgingAdminFunction() {
+    private IParseFunction createParseFunction(Class<?> clazz, String methodName, Class<?>... parameterTypes) {
         try {
-            Method method = CustomFunctions.class.getDeclaredMethod("isAdmin", Integer.class);
+            Method method = clazz.getDeclaredMethod(methodName, parameterTypes);
             return IParseFunction.fromLambda(method);
         } catch (NoSuchMethodException e) {
             e.printStackTrace();
             return null;
         }
+    }
+
+    @Bean
+    public IParseFunction judgingAdminFunction() {
+        return createParseFunction(CustomFunctions.class, "isAdmin", Integer.class);
     }
 
     @Bean
     public IParseFunction userDetailParseFunction() {
-        try {
-            Method method = CustomFunctions.class.getDeclaredMethod("userDetail", String.class);
-            return IParseFunction.fromLambda(method);
-        } catch (NoSuchMethodException e) {
-            e.printStackTrace();
-            return null;
-        }
+        return createParseFunction(CustomFunctions.class, "userDetail", String.class);
     }
 
     @Bean
-    public IParseFunction orderDetailParseFunction() {
-        try {
-            Method method = CustomFunctions.class.getDeclaredMethod("orderDetail", Long.class);
-            return IParseFunction.fromLambda(method);
-        } catch (NoSuchMethodException e) {
-            e.printStackTrace();
-            return null;
-        }
+    public IParseFunction getOldOrderParseFunction() {
+        return createParseFunction(CustomFunctions.class, "getOldOrder", Long.class);
     }
 }

--- a/oplog-example/src/main/java/com/elltor/example/config/CustomFunctionConfiguration.java
+++ b/oplog-example/src/main/java/com/elltor/example/config/CustomFunctionConfiguration.java
@@ -1,0 +1,45 @@
+package com.elltor.example.config;
+
+import com.elltor.example.config.Functions.CustomFunctions;
+import com.elltor.oplog.service.IParseFunction;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.lang.reflect.Method;
+
+@Configuration
+public class CustomFunctionConfiguration {
+
+    @Bean
+    public IParseFunction judgingAdminFunction() {
+        try {
+            Method method = CustomFunctions.class.getDeclaredMethod("isAdmin", Integer.class);
+            return IParseFunction.fromLambda(method);
+        } catch (NoSuchMethodException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    @Bean
+    public IParseFunction userDetailParseFunction() {
+        try {
+            Method method = CustomFunctions.class.getDeclaredMethod("userDetail", String.class);
+            return IParseFunction.fromLambda(method);
+        } catch (NoSuchMethodException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    @Bean
+    public IParseFunction orderDetailParseFunction() {
+        try {
+            Method method = CustomFunctions.class.getDeclaredMethod("orderDetail", Long.class);
+            return IParseFunction.fromLambda(method);
+        } catch (NoSuchMethodException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+}

--- a/oplog-example/src/main/java/com/elltor/example/config/Functions/CustomFunctions.java
+++ b/oplog-example/src/main/java/com/elltor/example/config/Functions/CustomFunctions.java
@@ -1,0 +1,22 @@
+package com.elltor.example.config.Functions;
+
+public class CustomFunctions {
+
+    static String isAdmin(Integer uid) {
+        if (uid == null) {
+            return "false";
+        }
+        return uid % 2 == 0 ? "true" : "false";
+    }
+
+    static String userDetail(String username) {
+        String res = username + " 男" + " 18";
+        return res;
+    }
+
+    static String orderDetail(Long id) {
+        return "【 id : " + id + "订单名称：男士卫衣一件 地址：北京市海淀区 】";
+    }
+
+
+}


### PR DESCRIPTION
减少自定义函数的冗余，使用Lambda表达式和一个通用的函数接口。在一个单独的类中实现多个自定义函数，然后通过Lambda表达式将它们注册到IParseFunction。